### PR TITLE
Elgandoz patch 1 (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ initTOC({
 - `String:selector`: headers selector, default is `'h1, h2, h3, h4, h5, h6'`.
 - `String:scope`: selector to specify elements search scope, default is `'body'`.
 - `Boolean:overwrite`: whether to overwrite existed headers' id, default is `false`, which means plugin will preserve the existed id property and create a string like `toc-1` for those don't have id assigned.
-- `String:prefix`: string to prepend to id/href property, default is `'toc'`, which generates a string like `toc-0`.
+- `String:prefix`: string to prepend to id/href property, default is `'toc'`, which generates a string like `toc-0`. Set to `true` to generate an automatic prefix based on the title.
 
 ## Example
 

--- a/src/jquery.toc.js
+++ b/src/jquery.toc.js
@@ -59,6 +59,16 @@
     };
 
     /**
+     * convert a string of text to a url slug
+     * @param {String} text: title or any string
+     *
+     * @return {String} text: url slug
+     */
+    var convertToUrl = function (text) {
+        return text.toLowerCase().replace(/ /g, '-').replace(/[-]+/g, '-').replace(/[^\w-]+/g, '');
+    }
+
+    /**
      * set element href/id and content
      * @param {Boolean} overwrite: whether overwrite source element existed id
      * @param {String} prefix: prefix to prepend to href/id
@@ -68,7 +78,7 @@
     var setAttrs = function (overwrite, prefix) {
         return function ($src, $target, index) {
             var content = $src.text();
-            var pre = prefix + '-' + index;
+            var pre = prefix === true ? convertToUrl(content) : prefix + '-' + index;
             $target.text(content);
 
             var src = $src[0];

--- a/src/toc.js
+++ b/src/toc.js
@@ -55,11 +55,15 @@
 
         return currentWrapper;
     };
+    
+    var convertToUrl = function (text) {
+        return text.toLowerCase().replace(/ /g, '-').replace(/[-]+/g, '-').replace(/[^\w-]+/g, '');
+    }
 
     var setAttrs = function (overwrite, prefix) {
         return function (src, target, index) {
             var content = src.textContent;
-            var pre = prefix + '-' + index;
+            var pre = prefix === true ? convertToUrl(content) : prefix + '-' + index;
             target.textContent = content;
 
             var id = overwrite ? pre : (src.id || pre);


### PR DESCRIPTION
Add automatic prefix based on title.

```js
let toc = initTOC({
  selector: 'h2',
  prefix: true
})
```
The above code will generate links like `#this-is-the-header-title`.
It maintains all the previous behaviours and defaults.

The `convertToUrl()` logic is taken from [this answer](https://stackoverflow.com/questions/1053902/how-to-convert-a-title-to-a-url-slug-in-jquery#comment-34216351).

It requires minification for the dist folder.
